### PR TITLE
added new options to /kicknoob

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_kicknoob.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_kicknoob.java
@@ -8,21 +8,31 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = AdminLevel.SENIOR, source = SourceType.BOTH, block_host_console = true)
-@CommandParameters(description = "Kick all non-superadmins on server.", usage = "/<command>")
+@CommandParameters(description = "Kick all non-superadmins on server.", usage = "/<command> (annon)")
 public class Command_kicknoob extends TFM_Command
 {
     @Override
     public boolean run(CommandSender sender, Player sender_p, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-        TFM_Util.adminAction(sender.getName(), "Disconnecting all non-superadmins.", true);
+        TFM_Util.adminAction(sender.getName(), sender_p + "Disconnecting all non-superadmins.", true);
 
         for (Player p : server.getOnlinePlayers())
         {
             if (!TFM_SuperadminList.isUserSuperadmin(p))
             {
-                p.kickPlayer(ChatColor.RED + "Disconnected by admin.");
+                p.kickPlayer(ChatColor.RED + "Disconnected by" + sender_p);
             }
         }
+        String mode = args[0].toLowerCase();
+        if (mode.equalsIgnoreCase("annon"))
+        for (Player p : server.getOnlinePlayers())
+        {
+            if (!TFM_SuperadminList.isUserSuperadmin(p))
+            {
+                p.kickPlayer(ChatColor.RED + "Disconnected by a admin");
+            }
+        }
+    
 
         return true;
     }


### PR DESCRIPTION
If normal /kicknoob is executed it will display the admin who kicked them, if you do /kicknoob annon then it will not display who kicked everyone. When it does the admin action broadcast, it will always say who kicked everyone!
