### PR TITLE
Log IP addresses in join messages.

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -693,7 +693,7 @@ public class TFM_PlayerListener implements Listener
             final String IP = player.getAddress().getAddress().getHostAddress().trim();
 
             // Log join message, as 1.7 doesn't log it anymore
-            TFM_Log.info(player.getName() + " joined the game with IP address " + IP);
+            TFM_Log.info(player.getName() + " joined the game with IP address: " + IP);
 
             TFM_UserList.getInstance(TotalFreedomMod.plugin).addUser(player);
 


### PR DESCRIPTION
This will make finding a player's IP address after a crash much easier.
