### PR TITLE
Added extra blocked commands used to bypass //brush

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -90,6 +90,8 @@ blocked_commands:
   - 's:b://:_'
   - 's:b:/superpickaxe:_'
   - 's:b:/brush:_'
+  - 's:b:/size:_'
+  - 's:b://mask:_'
   - 's:b:/mat:_'
   - 's:b:/tool:_'
   - 's:b://butcher:_'


### PR DESCRIPTION
I've added commands which enable //brush even though it is blocked (/size and //mask) to the blocked commands list (for superadmins only).

Resolves #319
