### PR TITLE
Blocked /mask, /gmask, /br, /lrbuild and /setworldspawn

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -120,6 +120,9 @@ blocked_commands:
   - 's:b:/mask:_'
   - 's:b:/gmask:_'
   - 's:b:/setworldspawn:_'
+  - 's:b:/br:_'
+  - 's:b:/tool:_'
+  - 's:b:/lrbuild:_'
 
   # Superadmin commands - Auto-eject
   - 's:a:/stop:_'

--- a/src/config.yml
+++ b/src/config.yml
@@ -119,8 +119,6 @@ blocked_commands:
   - 's:b:/eco reset:_'
   - 's:b:/mask:_'
   - 's:b:/gmask:_'
-  - 's:b:/setworldspawn:_'
-  - 's:b:/br:_'
   - 's:b:/tool:_'
   - 's:b:/lrbuild:_'
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -121,6 +121,8 @@ blocked_commands:
   - 's:b:/gmask:_'
   - 's:b:/tool:_'
   - 's:b:/lrbuild:_'
+  - 's:b:/defaultgamemode:_'
+  
 
   # Superadmin commands - Auto-eject
   - 's:a:/stop:_'

--- a/src/config.yml
+++ b/src/config.yml
@@ -117,6 +117,9 @@ blocked_commands:
   - 's:b:/setidletimeout:_'
   - 's:b:/mail sendall:_'
   - 's:b:/eco reset:_'
+  - 's:b:/mask:_'
+  - 's:b:/gmask:_'
+  - 's:b:/setworldspawn:_'
 
   # Superadmin commands - Auto-eject
   - 's:a:/stop:_'


### PR DESCRIPTION
I blocked some commands that were commonly requested to be blocked such as /mask, /gmask, /br, /lrbuild, etc. Also /setworldspawn does the same thing as /setspawn and needed to be blocked too.

Fixes #492.