### PR TITLE
Updated opme to make things alot easiler

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_opme.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_opme.java
@@ -2,7 +2,8 @@ package me.StevenLawson.TotalFreedomMod.Commands;
 
 import me.StevenLawson.TotalFreedomMod.TFM_Util;
 import org.bukkit.command.Command;
-import me.StevenLawson.TotalFreedomMod.*;
+import me.StevenLawson.TotalFreedomMod.TFM_AdminList;
+import me.StevenLawson.TotalFreedomMod.TotalFreedomMod;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -20,7 +21,6 @@ public class Command_opme extends TFM_Command
                {
                sender.sendMessage("You are a Imposter, You need to verify first");
                 sender.setOp(false);
-            sender.sendMessage(TotalFreedomMod.YOU_ARE_NOT_OP);
                }
         return true;
     }

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_opme.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_opme.java
@@ -2,10 +2,11 @@ package me.StevenLawson.TotalFreedomMod.Commands;
 
 import me.StevenLawson.TotalFreedomMod.TFM_Util;
 import org.bukkit.command.Command;
+import me.StevenLawson.TotalFreedomMod.*;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-@CommandPermissions(level = AdminLevel.SUPER, source = SourceType.ONLY_IN_GAME)
+@CommandPermissions(level = AdminLevel.ALL, source = SourceType.ONLY_IN_GAME)
 @CommandParameters(description = "Automatically ops user.", usage = "/<command>")
 public class Command_opme extends TFM_Command
 {
@@ -14,8 +15,13 @@ public class Command_opme extends TFM_Command
     {
         TFM_Util.adminAction(sender.getName(), "Opping " + sender.getName(), false);
         sender.setOp(true);
-        sender.sendMessage(TFM_Command.YOU_ARE_OP);
-
+            sender.sendMessage(TotalFreedomMod.YOU_ARE_OP);
+               if (!TFM_AdminList.isAdminImpostor(sender_p))
+               {
+               sender.sendMessage("You are a Imposter, You need to verify first");
+                sender.setOp(false);
+            sender.sendMessage(TotalFreedomMod.YOU_ARE_NOT_OP);
+               }
         return true;
     }
 }


### PR DESCRIPTION
The Command /opme was only open to admins, which is kinda unfair.
I updated the command /opme so when a new player joins or a player comes back from griefing..etc they can op them self rather them screaming and yelling in the chat  "OP ME!, OP pls" or having the admins do /opall everytime when a new player joins.

I blocked the command to Imposter so when a Imposter try to use /opme they will not get op, but  de-opped if they aren't de-opped already.
