### PR TITLE
Resolved issue #517 and W.E. issue

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -120,9 +120,9 @@ blocked_commands:
   - 's:b:/mask:_'
   - 's:b:/gmask:_'
   - 's:b:/tool:_'
-  - 's:b:/lrbuild:_'
+  - 's:b://lrbuild:_'
   - 's:b:/defaultgamemode:_'
-  
+  - 's:b://regen:_'
 
   # Superadmin commands - Auto-eject
   - 's:a:/stop:_'


### PR DESCRIPTION
The following should fix the blocking of '/lrbuild' as well with block the usage of '//regen' for non-administrators.  This is due to, as stated in #517, '//regen' lacks the ability for limiting.