### PR TITLE
Blocked /op causes too much spam.

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -95,6 +95,7 @@ blocked_commands:
   - 'n:b:/effect:Please use /potion to set effects.'
   - 'n:b:/enderchest:_'
   - 'n:b:/spreadplayers:_'
+  - 'n:b:/op:_'
 
   # Superadmin commands
   - 's:b:/kick:_'


### PR DESCRIPTION
I basically blocked op because we already have /qop which causes much less spam to op players.