### PR TITLE
Display correct number of IP bans.

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/TFM_BanManager.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_BanManager.java
@@ -110,7 +110,7 @@ public class TFM_BanManager
 
     public static List<TFM_Ban> getIpBanList()
     {
-        return Collections.unmodifiableList(uuidBans);
+        return Collections.unmodifiableList(ipBans);
     }
 
     public static List<TFM_Ban> getUuidBanList()


### PR DESCRIPTION
```getIpBanList()``` returns UUID bans rather than IP bans.