### PR TITLE
Modify glist ban so it uses the config.yml appeal URL.

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_glist.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_glist.java
@@ -5,6 +5,7 @@ import java.util.List;
 import me.StevenLawson.TotalFreedomMod.TFM_AdminList;
 import me.StevenLawson.TotalFreedomMod.TFM_Ban;
 import me.StevenLawson.TotalFreedomMod.TFM_BanManager;
+import me.StevenLawson.TotalFreedomMod.Config.TFM_ConfigEntry;
 import me.StevenLawson.TotalFreedomMod.TFM_Player;
 import me.StevenLawson.TotalFreedomMod.TFM_PlayerList;
 import me.StevenLawson.TotalFreedomMod.TFM_Util;
@@ -82,7 +83,7 @@ public class Command_glist extends TFM_Command
                 if (target != null)
                 {
                     TFM_BanManager.addUuidBan(new TFM_Ban(TFM_UuidManager.getUniqueId(target), target.getName()));
-                    target.kickPlayer("You have been banned by " + sender.getName() + "\n If you think you have been banned wrongly, appeal here: http://www.totalfreedom.boards.net");
+                    target.kickPlayer("You have been banned by " + sender.getName() + "\n If you think you have been banned wrongly, appeal here: " + TFM_ConfigEntry.SERVER_BAN_URL.getString());
                 }
                 else
                 {


### PR DESCRIPTION
When you glist ban an online player, it says totalfreedom.boards.net regardless of the config entry. I modified it so it is the config.yml's ban appeal URL.