### PR TITLE
Add admin name in /gtfo kick message

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
@@ -98,7 +98,7 @@ public class Command_gtfo extends TFM_Command
         TFM_BanManager.addUuidBan(new TFM_Ban(TFM_UuidManager.getUniqueId(player), player.getName(), sender.getName(), null, reason));
 
         // kick Player:
-        player.kickPlayer(ChatColor.RED + "You have been banned, GTFO!" + (reason != null ? ("\nReason: " + ChatColor.YELLOW + reason) : "") + " - " + sender.getName());
+        player.kickPlayer(ChatColor.RED + "GTFO!" + (reason != null ? ("\nReason: " + ChatColor.YELLOW + reason) : "") + " \nBanned by: " + sender.getName());
         return true;
     }
 }

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
@@ -98,7 +98,7 @@ public class Command_gtfo extends TFM_Command
         TFM_BanManager.addUuidBan(new TFM_Ban(TFM_UuidManager.getUniqueId(player), player.getName(), sender.getName(), null, reason));
 
         // kick Player:
-        player.kickPlayer(ChatColor.RED + "GTFO!" + (reason != null ? ("\nReason: " + ChatColor.YELLOW + reason) : "") + " \nBanned by: " + sender.getName());
+        player.kickPlayer(ChatColor.RED + "GTFO!" + (reason != null ? ("\nReason: " + ChatColor.YELLOW + reason) : "") + "\nBanned by: " + sender.getName());
         return true;
     }
 }

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gtfo.java
@@ -98,8 +98,7 @@ public class Command_gtfo extends TFM_Command
         TFM_BanManager.addUuidBan(new TFM_Ban(TFM_UuidManager.getUniqueId(player), player.getName(), sender.getName(), null, reason));
 
         // kick Player:
-        player.kickPlayer(ChatColor.RED + "GTFO" + (reason != null ? ("\nReason: " + ChatColor.YELLOW + reason) : ""));
-
+        player.kickPlayer(ChatColor.RED + "You have been banned, GTFO!" + (reason != null ? ("\nReason: " + ChatColor.YELLOW + reason) : "") + " - " + sender.getName());
         return true;
     }
 }


### PR DESCRIPTION
On the kick player area adds the sender (Admin) who banned the op.

It will clear up confusion when OPS do not know who banned them.

c3b09a64f6a5f3a7405c818a8e398045c7ce3ea9