### PR TITLE
Block /execute. Fixes #630

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -95,6 +95,7 @@ blocked_commands:
   - 'n:b:/effect:Please use /potion to set effects.'
   - 'n:b:/enderchest:_'
   - 'n:b:/spreadplayers:_'
+  - 'n:b:/execute:_'
 
   # Superadmin commands
   - 's:b:/kick:_'


### PR DESCRIPTION
/execute allows any command to be run as console, including admin commands. This needs to be blocked ASAP as a few people have abused it today.