### PR TITLE
Block /fill for non-superadmins. Fixes #634

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -129,6 +129,7 @@ blocked_commands:
   - 's:b:/tpall:_'
   - 's:b:/setblock:_'
   - 's:b:/green:_'
+  - 's:b:/fill:_'
 
   # Superadmin commands - Auto-eject
   - 's:a:/save-all:_'


### PR DESCRIPTION
/fill currently bypasses the WorldEdit limits and blocks, and until we get that worked out, I believe /fill should be blocked for non-supers.