### PR TITLE
Prevent, and fix existing illegal positions

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -788,7 +788,6 @@ public class TFM_PlayerListener implements Listener
         final Player player = event.getPlayer();
         final String ip = TFM_Util.getIp(player);
         final TFM_Player playerEntry;
-        
         TFM_Log.info("[JOIN] " + TFM_Util.formatPlayer(player) + " joined the game with IP address: " + ip, true);
         // Check absolute value to account for negatives
         if(Math.abs(player.getLocation().getX()) >= 30000000 || Math.abs(player.getLocation().getZ()) >= 30000000)

--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -387,15 +387,8 @@ public class TFM_PlayerListener implements Listener
         final Player player = event.getPlayer();
         final TFM_PlayerData playerdata = TFM_PlayerData.getPlayerData(player);
         
-        final Player player = event.getPlayer();
-        final TFM_PlayerData playerdata = TFM_PlayerData.getPlayerData(player);
-        
-        // Get coordinates of where the player is teleporting to
-        double teleportX = event.getTo().getX();
-        double teleportZ = event.getTo().getZ();
-        
         // Check absolute value to account for negatives
-        if(Math.abs(teleportX) >= 30000000 || Math.abs(teleportZ) >= 30000000)
+        if(Math.abs(event.getTo().getX()) >= 30000000 || Math.abs(event.getTo().getZ()) >= 30000000)
         {
             // Player teleported to illegal position, cancel it
             event.setCancelled(true);
@@ -794,22 +787,15 @@ public class TFM_PlayerListener implements Listener
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event)
     {
-
         final Player player = event.getPlayer();
         final String ip = TFM_Util.getIp(player);
         final TFM_Player playerEntry;
         
         TFM_Log.info("[JOIN] " + TFM_Util.formatPlayer(player) + " joined the game with IP address: " + ip, true);
-
-        // Get coordinates of player
-        double playerX = player.getLocation().getX();
-        double playerZ = player.getLocation().getZ();
-        
         // Get the spawn location
         Location spawnLocation = player.getWorld().getSpawnLocation();
-        
         // Check absolute value to account for negatives
-        if(Math.abs(playerX) >= 30000000 || Math.abs(playerZ) >= 30000000)
+        if(Math.abs(player.getLocation().getX()) >= 30000000 || Math.abs(player.getLocation().getZ()) >= 30000000)
         {
             // Illegal position, teleport to spawn
             player.teleport(spawnLocation);

--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -386,6 +386,20 @@ public class TFM_PlayerListener implements Listener
     {
         final Player player = event.getPlayer();
         final TFM_PlayerData playerdata = TFM_PlayerData.getPlayerData(player);
+        
+        final Player player = event.getPlayer();
+        final TFM_PlayerData playerdata = TFM_PlayerData.getPlayerData(player);
+        
+        // Get coordinates of where the player is teleporting to
+        double teleportX = event.getTo().getX();
+        double teleportZ = event.getTo().getZ();
+        
+        // Check absolute value to account for negatives
+        if(Math.abs(teleportX) >= 30000000 || Math.abs(teleportZ) >= 30000000)
+        {
+            // Player teleported to illegal position, cancel it
+            event.setCancelled(true);
+        }
 
         if (!TFM_AdminList.isSuperAdmin(player) && playerdata.isFrozen())
         {
@@ -784,8 +798,22 @@ public class TFM_PlayerListener implements Listener
         final Player player = event.getPlayer();
         final String ip = TFM_Util.getIp(player);
         final TFM_Player playerEntry;
-
+        
         TFM_Log.info("[JOIN] " + TFM_Util.formatPlayer(player) + " joined the game with IP address: " + ip, true);
+
+        // Get coordinates of player
+        double playerX = player.getLocation().getX();
+        double playerZ = player.getLocation().getZ();
+        
+        // Get the spawn location
+        Location spawnLocation = player.getWorld().getSpawnLocation();
+        
+        // Check absolute value to account for negatives
+        if(Math.abs(playerX) >= 30000000 || Math.abs(playerZ) >= 30000000)
+        {
+            // Illegal position, teleport to spawn
+            player.teleport(spawnLocation);
+        }
 
         // Handle PlayerList entry (persistent)
         if (TFM_PlayerList.existsEntry(player))

--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -386,12 +386,10 @@ public class TFM_PlayerListener implements Listener
     {
         final Player player = event.getPlayer();
         final TFM_PlayerData playerdata = TFM_PlayerData.getPlayerData(player);
-        
         // Check absolute value to account for negatives
         if(Math.abs(event.getTo().getX()) >= 30000000 || Math.abs(event.getTo().getZ()) >= 30000000)
         {
-            // Player teleported to illegal position, cancel it
-            event.setCancelled(true);
+            event.setCancelled(true); // illegal position, cancel it
         }
 
         if (!TFM_AdminList.isSuperAdmin(player) && playerdata.isFrozen())
@@ -792,15 +790,11 @@ public class TFM_PlayerListener implements Listener
         final TFM_Player playerEntry;
         
         TFM_Log.info("[JOIN] " + TFM_Util.formatPlayer(player) + " joined the game with IP address: " + ip, true);
-        // Get the spawn location
-        Location spawnLocation = player.getWorld().getSpawnLocation();
         // Check absolute value to account for negatives
         if(Math.abs(player.getLocation().getX()) >= 30000000 || Math.abs(player.getLocation().getZ()) >= 30000000)
         {
-            // Illegal position, teleport to spawn
-            player.teleport(spawnLocation);
+            player.teleport(player.getWorld().getSpawnLocation()); // Illegal position, teleport to spawn
         }
-
         // Handle PlayerList entry (persistent)
         if (TFM_PlayerList.existsEntry(player))
         {


### PR DESCRIPTION
Fixes the illegal position exploit. Resolves #651.
Prevents the illegal position from ever happening by checking the coordinates when a player teleports and canceling if the teleport would put them into an illegal position. Fixes existing illegal positions by checking coordinates on join, and sending the player to spawn if it is an illegal position.

I have tested the code and it seems to work fine.
