### PR TITLE
2-character usernames can now login

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
@@ -71,7 +71,7 @@ public class TFM_ServerInterface
         final UUID uuid = TFM_UuidManager.newPlayer(player, ip);
 
         // Perform username checks
-        if (username.length() < 3 || username.length() > TotalFreedomMod.MAX_USERNAME_LENGTH)
+        if (username.length() < 2 || username.length() > TotalFreedomMod.MAX_USERNAME_LENGTH)
         {
             event.disallow(Result.KICK_OTHER, "Your username is an invalid length (must be between 3 and 20 characters long).");
             return;

--- a/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
@@ -73,7 +73,7 @@ public class TFM_ServerInterface
         // Perform username checks
         if (username.length() < 2 || username.length() > TotalFreedomMod.MAX_USERNAME_LENGTH)
         {
-            event.disallow(Result.KICK_OTHER, "Your username is an invalid length (must be between 3 and 20 characters long).");
+            event.disallow(Result.KICK_OTHER, "Your username is an invalid length (must be between 2 and 20 characters long).");
             return;
         }
 


### PR DESCRIPTION
[16:18:03] [Thread-112/INFO]: UUID of player 5m is 1fe6be27-3283-3118-911c-fbb124d5d1b1
[16:18:03] [Server thread/INFO]: [TotalFreedomMod] Obtaining UUID for new player: 5m
[16:18:03] [Server thread/INFO]: Disconnecting com.mojang.authlib.GameProfile@4ccce6e6[id=1fe6be27-3283-3118-911c-fbb124d5d1b1,name=5m,properties={},legacy=false] (/185.43.110.xx:59584): Your username is an invalid length (must be between 3 and 20 characters long).
[16:18:03] [Server thread/INFO]: com.mojang.authlib.GameProfile@4ccce6e6[id=1fe6be27-3283-3118-911c-fbb124d5d1b1,name=5m,properties={},legacy=false] (/185.43.110.xx:59584) lost connection: Your username is an invalid length (must be between 3 and 20 characters long).

Turns out that name is an actual premium username and they couldn't join.