### PR TITLE
Block /jail and /unjail. Fixes #671

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -97,6 +97,7 @@ blocked_commands:
   - 'n:b:/spreadplayers:_'
   - 'n:b:/execute:_'
   - 'n:b:/jail:_'
+  - 'n:b:/unjail:_'
 
   # Superadmin commands
   - 's:b:/kick:_'

--- a/src/config.yml
+++ b/src/config.yml
@@ -96,6 +96,7 @@ blocked_commands:
   - 'n:b:/enderchest:_'
   - 'n:b:/spreadplayers:_'
   - 'n:b:/execute:_'
+  - 'n:b:/jail:_'
 
   # Superadmin commands
   - 's:b:/kick:_'


### PR DESCRIPTION
Today, I came on as an alt and as soon as I joined, I was jailed and the jailer refused to let me out even after I told him I was an admin. He only believed me after I went ingame on my normal account and noobed him. Superadmins won't be needing this command either as we have /cage.