### PR TITLE
Block /regen and /replacenear

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -134,6 +134,8 @@ blocked_commands:
   - 's:b:/green:_'
   - 'n:b:/gamerule:_'
   - 'n:b:/togglejail:_'
+  - 'n:b:/regen:_'
+  - 'n:b:/replacenear:_'
 
   # Superadmin commands - Auto-eject
   - 's:a:/stop:_'


### PR DESCRIPTION
Well, All these commands are used for is crashing the server.

Why not just block them so only SuperAdmin+ can use these commands.