### PR TITLE
Don't remove italics when using /nickclean.

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_nickclean.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_nickclean.java
@@ -18,7 +18,6 @@ public class Command_nickclean extends TFM_Command
     {
         ChatColor.MAGIC,
         ChatColor.STRIKETHROUGH,
-        ChatColor.ITALIC,
         ChatColor.UNDERLINE,
         ChatColor.BLACK
     };


### PR DESCRIPTION
Currently italics are allowed; and nickclean wipes any user's nickname if it contains such characters.
See http://totalfreedom.boards.net/thread/26577/allow-italics.