### PR TITLE
Add onlinemode on/off notification - closes #778

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_ServerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_ServerListener.java
@@ -51,6 +51,8 @@ public class TFM_ServerListener implements Listener
         // Colorful MOTD
 
         final StringBuilder motd = new StringBuilder();
+        
+        motd.append(Bukkit.getServer().getOnlineMode() ? "•" : "○");
 
         for (String word : TFM_ConfigEntry.SERVER_MOTD.getString().replace("%mcversion%", TFM_ServerInterface.getVersion()).split(" "))
         {


### PR DESCRIPTION
What this does is if onlinemode is on, it adds a full circle "•" at the beginning of the MOTD. If it is off, it adds an empty circle at the end "○".

This code has been tested and works exactly as it should.