### PR TITLE
Add a Telnet Clan. Admin rank.

### DIFF
--- a/buildnumber.properties
+++ b/buildnumber.properties
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Sat May 30 21:50:19 CEST 2015
-build.number=1053
+#Thu Jun 11 22:27:16 CEST 2015
+build.number=1054

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_invis.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_invis.java
@@ -59,7 +59,7 @@ public class Command_invis extends TFM_Command
         }
         else
         {
-            playerMsg("Invisble players (" + players.size() + "): " + StringUtils.join(players, ", "));
+            playerMsg("Invisible players (" + players.size() + "): " + StringUtils.join(players, ", "));
         }
 
         return true;

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_kicknoob.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_kicknoob.java
@@ -20,7 +20,7 @@ public class Command_kicknoob extends TFM_Command
         {
             if (!TFM_AdminList.isSuperAdmin(player))
             {
-                player.kickPlayer(ChatColor.RED + "Disconnected by admin.");
+                player.kickPlayer(ChatColor.RED + "All non-superadmins were kicked by " + sender.getName() + ".");
             }
         }
 

--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -81,7 +81,7 @@ public class TFM_PlayerListener implements Listener
                 {
                     case WATER_BUCKET:
                     {
-                        if (TFM_ConfigEntry.ALLOW_WATER_PLACE.getBoolean())
+                        if (TFM_AdminList.isSuperAdmin(player) || TFM_ConfigEntry.ALLOW_WATER_PLACE.getBoolean())
                         {
                             break;
                         }
@@ -94,7 +94,7 @@ public class TFM_PlayerListener implements Listener
 
                     case LAVA_BUCKET:
                     {
-                        if (TFM_ConfigEntry.ALLOW_LAVA_PLACE.getBoolean())
+                        if (TFM_AdminList.isSuperAdmin(player) || TFM_ConfigEntry.ALLOW_LAVA_PLACE.getBoolean())
                         {
                             break;
                         }

--- a/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import me.StevenLawson.TotalFreedomMod.Config.TFM_ConfigEntry;
-import static me.StevenLawson.TotalFreedomMod.Listener.TFM_PlayerListener.DEFAULT_PORT;
-import net.minecraft.server.v1_8_R2.EntityPlayer;
-import net.minecraft.server.v1_8_R2.MinecraftServer;
-import net.minecraft.server.v1_8_R2.PropertyManager;
+import me.StevenLawson.TotalFreedomMod.Listener.TFM_PlayerListener;
+import net.minecraft.server.v1_8_R3.EntityPlayer;
+import net.minecraft.server.v1_8_R3.MinecraftServer;
+import net.minecraft.server.v1_8_R3.PropertyManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -18,7 +18,7 @@ import org.bukkit.event.player.PlayerLoginEvent.Result;
 
 public class TFM_ServerInterface
 {
-    public static final String COMPILE_NMS_VERSION = "v1_8_R2";
+    public static final String COMPILE_NMS_VERSION = "v1_8_R3";
     public static final Pattern USERNAME_REGEX = Pattern.compile("^[\\w\\d_]{3,20}$");
 
     public static void setOnlineMode(boolean mode)
@@ -121,7 +121,7 @@ public class TFM_ServerInterface
                 final int forceIpPort = TFM_ConfigEntry.FORCE_IP_PORT.getInteger();
                 event.disallow(PlayerLoginEvent.Result.KICK_OTHER,
                         TFM_ConfigEntry.FORCE_IP_KICKMSG.getString()
-                        .replace("%address%", TFM_ConfigEntry.SERVER_ADDRESS.getString() + (forceIpPort == DEFAULT_PORT ? "" : ":" + forceIpPort)));
+                        .replace("%address%", TFM_ConfigEntry.SERVER_ADDRESS.getString() + (forceIpPort == TFM_PlayerListener.DEFAULT_PORT ? "" : ":" + forceIpPort)));
                 return;
             }
 

--- a/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_ServerInterface.java
@@ -112,7 +112,7 @@ public class TFM_ServerInterface
         // Check force-IP match
         if (TFM_ConfigEntry.FORCE_IP_ENABLED.getBoolean())
         {
-            final String hostname = event.getHostname().replace("FML", ""); // Forge fix - https://github.com/TotalFreedom/TotalFreedomMod/issues/493
+            final String hostname = event.getHostname().replace("\u0000FML\u0000", ""); // Forge fix - https://github.com/TotalFreedom/TotalFreedomMod/issues/493
             final String connectAddress = TFM_ConfigEntry.SERVER_ADDRESS.getString();
             final int connectPort = TotalFreedomMod.server.getPort();
 


### PR DESCRIPTION
We should add a Telnet Clan. Admin rank that can be toggled in superadmin.yml just like for STA and SrA. It'll be easier to compare whos normal STA and whos TCA because lots of people get confused. The colour for it can be &a and I have no clue anything else to say. :+1: 


Thanks,
~Fenix