### PR TITLE
Changing impostors gamemode.

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -847,7 +847,7 @@ public class TFM_PlayerListener implements Listener
             TFM_Util.bcastMsg(ChatColor.AQUA + player.getName() + " is " + TFM_PlayerRank.getLoginMessage(player));
             player.getInventory().clear();
             player.setOp(false);
-            player.setGameMode(GameMode.SURVIVAL);
+            player.setGameMode(GameMode.ADVENTURE);
             TFM_PlayerData.getPlayerData(player).setFrozen(true);
         }
         else if (TFM_AdminList.isSuperAdmin(player) || TFM_Util.DEVELOPERS.contains(player.getName()))


### PR DESCRIPTION
Players who pose as admins can still grief around them even though they're frozen. I made it so that if they join as an impostor, they're set to adventure mode instead of the default survival.