### PR TITLE
Issue fixed

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Listener/TFM_PlayerListener.java
@@ -359,7 +359,7 @@ public class TFM_PlayerListener implements Listener
                                 }
                                 TFM_Util.bcastMsg(msg.toString());
 
-                                player.getInventory().getItemInHand().setType(Material.POTATO_ITEM);
+                                player.getInventory().getItemInHand().setType(Material.POTATO);
                             }
 
                             event.setCancelled(true);


### PR DESCRIPTION
Where if a user used a clownfish and wasn't the rank, they got an untextured, black and purple checkerboard block.