### PR TITLE
Fixes UUIDs for /gadmin

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gadmin.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_gadmin.java
@@ -76,7 +76,7 @@ public class Command_gadmin extends TFM_Command
             while (it.hasNext())
             {
                 final Player player = it.next();
-                final String hash = TFM_UuidManager.getUniqueId(player).toString().substring(0, 4);
+                final String hash = TFM_UuidManager.getUniqueId(player).toString().substring(0, 11);
                 sender.sendMessage(ChatColor.GRAY + String.format("[ %s ] : [ %s ] - %s",
                         player.getName(),
                         ChatColor.stripColor(player.getDisplayName()),
@@ -94,7 +94,7 @@ public class Command_gadmin extends TFM_Command
         while (it.hasNext() && target == null)
         {
             final Player player = it.next();
-            final String hash = TFM_UuidManager.getUniqueId(player).toString().substring(0, 4);
+            final String hash = TFM_UuidManager.getUniqueId(player).toString().substring(0, 11);
 
             if (hash.equalsIgnoreCase(args[1]))
             {
@@ -161,7 +161,7 @@ public class Command_gadmin extends TFM_Command
             case OP:
             {
                 TFM_Util.adminAction(sender.getName(), String.format("Opping %s.", target.getName()), false);
-                target.setOp(false);
+                target.setOp(true);
                 target.sendMessage(TFM_Command.YOU_ARE_OP);
 
                 break;


### PR DESCRIPTION
1. I set the substring from 4 to 11 because if it was 4, it would only show "dead". If it was 11, it would show "deadbeef-" then a letter and a number after the dash. For example, when I tested this, it showed this:
"deadbeef-a8" as my UUID for /gadmin list. It actually works too, I tested one of the sub commands on myself and it worked fine.

2. In /gadmin op <targethash> it would set the to non-op, so I fixed that too so now it ops the player, not deops.