### PR TITLE
Create announce commands and method

### DIFF
--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
@@ -9,17 +9,19 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @CommandPermissions(level = AdminLevel.SUPER, source = SourceType.BOTH)
-@CommandParameters(description = "Announce a message", usage = "/<command>", aliases = "announcement, announcer")
+@CommandParameters(description = "Announce a message to the server as the broadcaster.", usage = "/<command>", aliases = "announcement, announcer")
 public class Command_announce extends TFM_Command
 {
     @Override
     public boolean run(CommandSender sender, Player sender_p, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-    //
-     public static void announce(final Player player)
-     {
+    
+      public static void announce(final Player player)
+      {
         String message = StringUtils.join(ArrayUtils.subarray(args, 0, args.length), " ");
         TFM_Util.bcastMsg(TFM_ConfigEntry.ANNOUNCER_PREFIX.getString().replaceAll("&", "§") + message + " (" + sender.getName() + ")");
         return true;
+      }
+         
     }
 }

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
@@ -1,0 +1,25 @@
+package me.StevenLawson.TotalFreedomMod.Commands;
+
+import me.StevenLawson.TotalFreedomMod.Config.TFM_ConfigEntry;
+import me.StevenLawson.TotalFreedomMod.TFM_Util;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@CommandPermissions(level = AdminLevel.SUPER, source = SourceType.BOTH)
+@CommandParameters(description = "Announce a message", usage = "/<command>", aliases = "announcement, announcer")
+public class Command_announce extends TFM_Command
+{
+    @Override
+    public boolean run(CommandSender sender, Player sender_p, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
+    {
+    //
+     public static void announce(final Player player)
+     {
+        String message = StringUtils.join(ArrayUtils.subarray(args, 0, args.length), " ");
+        TFM_Util.bcastMsg(TFM_ConfigEntry.ANNOUNCER_PREFIX.getString().replaceAll("&", "§") + message + " (" + sender.getName() + ")");
+        return true;
+    }
+}

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
@@ -15,11 +15,8 @@ public class Command_announce extends TFM_Command
     @Override
     public boolean run(CommandSender sender, Player sender_p, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-      public static void announce(final Player player)
-      {
-        String message = StringUtils.join(ArrayUtils.subarray(args, 0, args.length), " ");
-        TFM_Util.bcastMsg(TFM_ConfigEntry.ANNOUNCER_PREFIX.getString().replaceAll("&", "§") + message + " (" + sender.getName() + ")");
-        return true;
-      }
+      String message = StringUtils.join(ArrayUtils.subarray(args, 0, args.length), " ");
+      TFM_Util.bcastMsg(TFM_ConfigEntry.ANNOUNCER_PREFIX.getString().replaceAll("&", "§") + message);
+      return true;
     }
 }

--- a/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
+++ b/src/me/StevenLawson/TotalFreedomMod/Commands/Command_announce.java
@@ -15,13 +15,11 @@ public class Command_announce extends TFM_Command
     @Override
     public boolean run(CommandSender sender, Player sender_p, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
     {
-    
       public static void announce(final Player player)
       {
         String message = StringUtils.join(ArrayUtils.subarray(args, 0, args.length), " ");
         TFM_Util.bcastMsg(TFM_ConfigEntry.ANNOUNCER_PREFIX.getString().replaceAll("&", "§") + message + " (" + sender.getName() + ")");
         return true;
       }
-         
     }
 }

--- a/src/me/StevenLawson/TotalFreedomMod/TFM_Util.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_Util.java
@@ -114,7 +114,7 @@ public class TFM_Util
     {
         throw new AssertionError();
     }
-
+    
     public static void bcastMsg(String message, ChatColor color)
     {
         TFM_Log.info(message, true);
@@ -128,6 +128,16 @@ public class TFM_Util
     public static void bcastMsg(String message)
     {
         TFM_Util.bcastMsg(message, null);
+    }
+    
+    public static void announceMsg(String message, ChatColor color)
+    {
+        TFM_Util.bcastMsg(TFM_ConfigEntry.ANNOUNCER_PREFIX.getString().replaceAll("&", "§") + message);
+    }
+    
+    public static void announceMsg(String message)
+    {
+        TFM_Util.announceMsg(message, null);
     }
 
     // Still in use by listeners

--- a/src/me/StevenLawson/TotalFreedomMod/TFM_Util.java
+++ b/src/me/StevenLawson/TotalFreedomMod/TFM_Util.java
@@ -114,7 +114,7 @@ public class TFM_Util
     {
         throw new AssertionError();
     }
-    
+
     public static void bcastMsg(String message, ChatColor color)
     {
         TFM_Log.info(message, true);


### PR DESCRIPTION
Create announce commands and method
***
**Associated issue:** 
"/announce" (#803) 

**Why should we merge this:**
We should merge this because it has a good potential on the server because we can pretend to be announcements because if we want to announce something we can do it without having to make a PR or use /me and mimic the announcement prefix and the purple asterisk puts people off reading because they know it's fake and do not respond/notice it.

**Do you think it will be used?:**
Yes, as us admins want to announce things to the server with the announcement prefix it can have more use.

**Does this make a current feature more used?:**
Yes, It makes the announcement prefix more used as it is not widely used on this plugin.
***
Thank _you_ for reading this I hope you have a good day/night.