### PR TITLE
Fix small typo - /invis

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_invis.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_invis.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
 
 @CommandPermissions(level = Rank.SUPER_ADMIN, source = SourceType.BOTH)
-@CommandParameters(description = "Shows (optionally smites) invisisible players", usage = "/<command> (smite)")
+@CommandParameters(description = "Shows (optionally smites) invisible players", usage = "/<command> (smite)")
 public class Command_invis extends FreedomCommand
 {
 


### PR DESCRIPTION
Small typo - removes a second "is" in the description of /invis.