### PR TITLE
[Suggestion] Change formatting of /gtfo in-game

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/commands/Command_gtfo.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/commands/Command_gtfo.java
@@ -79,6 +79,8 @@ public class Command_gtfo extends FreedomCommand
         // Broadcast
         final StringBuilder bcast = new StringBuilder()
                 .append(ChatColor.RED)
+                .append("sender.getName()")
+                .append(" - ")
                 .append("Banning: ")
                 .append(player.getName())
                 .append(", IP: ")

--- a/src/main/java/me/totalfreedom/totalfreedommod/commands/Command_gtfo.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/commands/Command_gtfo.java
@@ -79,7 +79,7 @@ public class Command_gtfo extends FreedomCommand
         // Broadcast
         final StringBuilder bcast = new StringBuilder()
                 .append(ChatColor.RED)
-                .append("sender.getName()")
+                .append(sender.getName())
                 .append(" - ")
                 .append("Banning: ")
                 .append(player.getName())


### PR DESCRIPTION
Right now, the admin's name is automatically stated when the banned player tries to rejoin. As a result, we can't find who is banning a player (without going on logviewer) as we don't put our signature anymore.