### PR TITLE
Change formatting of /gtfo in-game

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_gtfo.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_gtfo.java
@@ -79,6 +79,8 @@ public class Command_gtfo extends FreedomCommand
         // Broadcast
         final StringBuilder bcast = new StringBuilder()
                 .append(ChatColor.RED)
+                .append(sender.getName)
+                .append(" - ")
                 .append("Banning: ")
                 .append(player.getName())
                 .append(", IP: ")


### PR DESCRIPTION
Added name to ban message in-game as admins no longer need to use a signature when banning.
