### PR TITLE
Link to TFM's official release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ TotalFreedomMod is a CraftBukkit server plugin designed primarily to support the
 This plugin was originally coded by StevenLawson (Madgeek1450), with Jerom van der Sar (Prozza) becoming heavily involved in its development some time later. It consists of over 85 custom coded commands and a large variety of distinguishable features not included in any other plugin. The plugin has since its beginning grown immensely. Together, with the main TotalFreedom server, TotalFreedomMod has a long-standing reputation of effectiveness whilst maintaining a clear feeling of openness towards the administrators and the players themselves.
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) if you are interested in developing TotalFreedomMod. For information on how TotalFreedomMod is licensed, please see [LICENSE.md](LICENSE.md).
+
+You may download precompiled versions, including prereleases, at TotalFreedom's official repository's [release page](https://github.com/TotalFreedom/TotalFreedomMod/releases).

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -232,7 +232,7 @@ announcer:
     - 'Save your buildings via WorldEdit! http://totalfreedom.me for more information!'
     - 'Famous players, such as Notch, are always fake! We are an offline/cracked server!'
     - 'You may contact TotalFreedom support on Twitter! https://tiny.re/tfsupport'
-    - 'You may download TotalFreedomMod here: https://tiny.re/tfm+'
+    - 'You may download TotalFreedomMod here: https://tiny.re/tfm'
     - 'MarkByron is the owner of TotalFreedom.'
     - 'Server lagging?  Check the lag via "/tps"'
     - 'You are allowed to record and stream videos on TotalFreedom.'


### PR DESCRIPTION
This will display a link to TFM's official release page on the front page to all for easier accessibility to the download page. I also resolved an issue (sorry for not having an open issue!) regarding linking to the releases page. Because it revolves around the TFM release page, I figured it was appropriate to fix this issue also. The plus-symbol links to statistics rather than the actual link. Therefore, by removing the plus symbol you will be able to access the TFM releases page directly.

This will resolve issue #1501.