### PR TITLE
Resolves #1644 | Fix /doom command

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_doom.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_doom.java
@@ -72,7 +72,7 @@ public class Command_doom extends FreedomCommand
         player.setFireTicks(10000);
 
         // Generate explosion
-        player.getWorld().createExplosion(player.getLocation(), 4F);
+        player.getWorld().createExplosion(player.getLocation(), 0F, false);
 
         // Shoot the player in the sky
         player.setVelocity(player.getVelocity().clone().add(new Vector(0, 20, 0)));
@@ -99,7 +99,7 @@ public class Command_doom extends FreedomCommand
                 FUtil.adminAction(sender.getName(), "Banning " + player.getName() + ", IP: " + ip, true);
 
                 // generate explosion
-                player.getWorld().createExplosion(player.getLocation(), 4F);
+                player.getWorld().createExplosion(player.getLocation(), 0F, false);
 
                 // kick player
                 player.kickPlayer(ChatColor.RED + "FUCKOFF, and get your shit together!");


### PR DESCRIPTION
This fixes the bug when using the /doom command. Currently blocks are destroyed when using /doom. Changing "4F" to "0F" changes the power of the explosion. Setting the boolean to false at the end of the statement disables fire on explosion.