### PR TITLE
Add an Aliases to AdminWorld

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_adminworld.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_adminworld.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.Player;
 
 @CommandPermissions(level = Rank.OP, source = SourceType.BOTH)
 @CommandParameters(description = "Go to the AdminWorld.",
-        usage = "/<command> [guest < list | purge | add <player> | remove <player> > | time <morning | noon | evening | night> | weather <off | on | storm>]")
+        usage = "/<command> [guest < list | purge | add <player> | remove <player> > | time <morning | noon | evening | night> | weather <off | on | storm>]", aliases = "aw")
 public class Command_adminworld extends FreedomCommand
 {
 


### PR DESCRIPTION
An alias to AdminWorld would be /aw . This could be helpful in some situations, when you have to rush and to find whether a player is griefing in the AdminWorld. Comments?