### PR TITLE
Resolves #1753 Disable written books

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/blocking/InteractBlocker.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/blocking/InteractBlocker.java
@@ -98,6 +98,14 @@ public class InteractBlocker extends FreedomService
                 event.setCancelled(true);
                 break;
             }
+            
+            case WRITTEN_BOOK:
+            {
+                player.getInventory().clear(player.getInventory().getHeldItemSlot());
+                player.sendMessage(ChatColor.GRAY + "Written books are currently disabled.");
+                event.setCancelled(true);
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
This resolves #1753 This will stop players from opening written books, thus putting an end to book exploits and crash books. This has been a major problem for a while now.
