### PR TITLE
Update Command_kick.java

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_kick.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_kick.java
@@ -28,12 +28,6 @@ public class Command_kick extends FreedomCommand
             return true;
         }
 
-        if (isAdmin(player))
-        {
-            msg("Admins can not be kicked", ChatColor.RED);
-            return true;
-        }
-
         String reason = null;
         if (args.length > 1)
         {


### PR DESCRIPTION
Kicking an online admin is often done with /gtfo. It rolls them back and keeps them banned if they are an imposter or desupered. This idea is not by me, credit goes to rovert.