### PR TITLE
Improved JSON API. Resolves #1884.

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_players.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_players.java
@@ -24,6 +24,7 @@ public class Module_players extends HTTPDModule
         final JSONObject responseObject = new JSONObject();
 
         final JSONArray players = new JSONArray();
+        final JSONArray onlineadmins = new JSONArray();
         final JSONArray superadmins = new JSONArray();
         final JSONArray telnetadmins = new JSONArray();
         final JSONArray senioradmins = new JSONArray();
@@ -33,6 +34,10 @@ public class Module_players extends HTTPDModule
         for (Player player : Bukkit.getOnlinePlayers())
         {
             players.add(player.getName());
+            if(plugin.al.isAdmin(player) && !plugin.al.isAdminImpostor(player))
+            {
+                onlineadmins.add(player.getName());
+            }
         }
 
         // Admins
@@ -58,6 +63,7 @@ public class Module_players extends HTTPDModule
         developers.addAll(FUtil.DEVELOPERS);
 
         responseObject.put("players", players);
+        responseObject.put("onlineadmins", onlineadmins);
         responseObject.put("superadmins", superadmins);
         responseObject.put("telnetadmins", telnetadmins);
         responseObject.put("senioradmins", senioradmins);

--- a/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_players.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/httpd/module/Module_players.java
@@ -34,7 +34,7 @@ public class Module_players extends HTTPDModule
         for (Player player : Bukkit.getOnlinePlayers())
         {
             players.add(player.getName());
-            if(plugin.al.isAdmin(player) && !plugin.al.isAdminImpostor(player))
+            if (plugin.al.isAdmin(player) && !plugin.al.isAdminImpostor(player))
             {
                 onlineadmins.add(player.getName());
             }


### PR DESCRIPTION
This commit allows external apps/plugins to see which admins are online through the HTTP API. This could be used to develop plugins quicker, without needing to integrate them directly into TFM.

It adds an 'onlineplayers' array to the json response for the players module.

I have tested this.