### PR TITLE
Added /Verified

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
@@ -22,7 +22,7 @@ public class Command_verified extends FreedomCommand
             
             if (isAdmin(player))
             {
-            FUtil.bcastMsg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
+             msg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
              + ChatColor.WHITE + "< " + ChatColor.RESET + "" + sender.getName() + ChatColor.WHITE + "> "
              + ChatColor.YELLOW + "Has verified and is requesting to be added!");
        }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
@@ -22,7 +22,7 @@ public class Command_verified extends FreedomCommand
             
             if (isAdmin(player))
             {
-             msg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
+             FUtil.msg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
              + ChatColor.WHITE + "< " + ChatColor.RESET + "" + sender.getName() + ChatColor.WHITE + "> "
              + ChatColor.YELLOW + "Has verified and is requesting to be added!");
        }

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
@@ -1,0 +1,26 @@
+package me.totalfreedom.totalfreedommod.command;
+
+import me.totalfreedom.totalfreedommod.rank.Rank;
+import me.totalfreedom.totalfreedommod.util.DepreciationAggregator;
+import me.totalfreedom.totalfreedommod.util.FUtil;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+@CommandPermissions(level = Rank.IMPOSTOR, source = SourceType.BOTH)
+@CommandParameters(description = "After an admin has verified, this let's other admins know they have with enhanced chat", usage = "/<command>")
+public class Command_verified extends FreedomCommand
+{
+
+    @Override
+    public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
+ {
+        FUtil.bcastMsg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
+        + ChatColor.WHITE + "< " + ChatColor.RESET + "" + sender.getName() + ChatColor.WHITE + "> "
+        + ChatColor.YELLOW + "Has verified and is requesting to be added!"
+        );
+
+        return true;
+    }
+}

--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_verified.java
@@ -16,10 +16,16 @@ public class Command_verified extends FreedomCommand
     @Override
     public boolean run(CommandSender sender, Player playerSender, Command cmd, String commandLabel, String[] args, boolean senderIsConsole)
  {
-        FUtil.bcastMsg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
-        + ChatColor.WHITE + "< " + ChatColor.RESET + "" + sender.getName() + ChatColor.WHITE + "> "
-        + ChatColor.YELLOW + "Has verified and is requesting to be added!"
-        );
+        
+        for (Player player : server.getOnlinePlayers())   
+        {
+            
+            if (isAdmin(player))
+            {
+            FUtil.bcastMsg(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Imposter" + ChatColor.GRAY + "] " 
+             + ChatColor.WHITE + "< " + ChatColor.RESET + "" + sender.getName() + ChatColor.WHITE + "> "
+             + ChatColor.YELLOW + "Has verified and is requesting to be added!");
+       }
 
         return true;
     }


### PR DESCRIPTION
This PR will fix the issue of admins that has verified and can't get added because they can't get a STA+ attention. This command let's the other know they have verified and are requesting to be added. Let me tell you how it works. After an admin has verified it broadcast's a message over public chat letting them know that they have verified and need to be added but with a certain format: [IMP] <(Player name)> (Yellow chat color) has verified and is requesting to be added. Ops cannot use this command because they need to be an imposter to use it. 